### PR TITLE
page had no title element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 xmlns:o="urn:schemas-microsoft-com:office:office"
 xmlns:w="urn:schemas-microsoft-com:office:word"
 xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
-xmlns="http://www.w3.org/TR/REC-html40">
+xmlns="http://www.w3.org/TR/REC-html40" lang="en">
 
 <head>
 <meta http-equiv=Content-Type content="text/html; charset=windows-1252">
@@ -10,7 +10,7 @@ xmlns="http://www.w3.org/TR/REC-html40">
 <meta name=Generator content="Microsoft Word 14">
 <meta name=Originator content="Microsoft Word 14">
 
-
+<title>Smarter Apps for Smarter Phones | GSM Alliance</title>
 
 <link rel=File-List href="SAG_files/filelist.xml">
 <link rel=Edit-Time-Data


### PR DESCRIPTION
The page had no `title` element and no `lang` attribute on the `html` element. The page also has other accessibility issues, especially bad `alt`attributes on each of the images.